### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -42,10 +42,14 @@ function _deepObjectTraverse(target, path, create = true) {
 		if (!_isObject(target[step])) {
 			if (create) target[step] = {};
 			else return undefined;
-		}
+		} else if (isPrototypePolluted(step)) continue;
 		target = target[step];
 	}
 	return target;
+}
+
+function isPrototypePolluted(key) {
+    return ['__proto__', 'constructor', 'prototype'].includes(key);
 }
 
 module.exports = {


### PR DESCRIPTION
### :bar_chart: Metadata *

`@szydlovski/deep-object` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40szydlovski%2Fdeep-object

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var deepObject = require("@szydlovski/deep-object")
var obj = {}
console.log("Before : " + {}.polluted);
deepObject.setProperty(obj, '__proto__.polluted', 'Yes! Its Polluted');
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i @szydlovski/deep-object # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![deep-object-fix](https://user-images.githubusercontent.com/43996156/102888896-a71a8300-447f-11eb-9904-77eaecf00e98.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
